### PR TITLE
Define a flux_time type for holding time values

### DIFF
--- a/src/fluxcapacitor.h
+++ b/src/fluxcapacitor.h
@@ -71,7 +71,7 @@ struct parent {
 
 	int started;
 
-	s128 time_drift;
+	flux_time time_drift;
 };
 
 
@@ -83,7 +83,7 @@ struct child {
 	struct list_head in_blocked;
 
 	int blocked;
-	s128 blocked_until;
+	flux_time blocked_until;
 
 	struct parent *parent;
 	struct trace_process *process;

--- a/src/main.c
+++ b/src/main.c
@@ -39,7 +39,7 @@ static void usage() {
 /* Global */
 struct options options;
 
-static s128 main_loop(char ***list_of_argv);
+static flux_time main_loop(char ***list_of_argv);
 
 int main(int argc, char **argv) {
 
@@ -210,7 +210,7 @@ static int on_trace(struct trace_process *process, int type, void *arg,
 	return 0;
 }
 
-static s128 main_loop(char ***list_of_argv) {
+static flux_time main_loop(char ***list_of_argv) {
 	struct timeval timeout;
 
 	struct parent *parent = parent_new();
@@ -318,8 +318,8 @@ static s128 main_loop(char ***list_of_argv) {
 		/* Hurray, we're most likely waiting for a timeout. */
 		struct child *min_child = parent_min_timeout_child(parent);
 		if (min_child) {
-			s128 now = (s128)TIMESPEC_NSEC(&uevent_now) + parent->time_drift;
-			s128 speedup = min_child->blocked_until - now;
+			flux_time now = (flux_time)TIMESPEC_NSEC(&uevent_now) + parent->time_drift;
+			flux_time speedup = min_child->blocked_until - now;
 			/* Don't speed up less than 10ms */
 			if (speedup > 0 && speedup < 10 * 1000000) {
 				SHOUT("[ ] %i too small speedup on %s(), waiting",
@@ -356,7 +356,7 @@ static s128 main_loop(char ***list_of_argv) {
 
 	trace_free(trace);
 
-	s128 time_drift = parent->time_drift;
+	flux_time time_drift = parent->time_drift;
 	free(parent);
 	free(uevent);
 

--- a/src/types.h
+++ b/src/types.h
@@ -12,7 +12,13 @@ typedef int8_t   s8;
 typedef int16_t  s16;
 typedef int32_t  s32;
 typedef int64_t  s64;
-typedef __int128  s128;
+
+#if defined(__x86_64__)
+	typedef __int128  s128;
+	typedef s128 flux_time;
+#else
+	typedef u64 flux_time;
+#endif
 
 
 #ifndef MIN

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -72,7 +72,7 @@ void wrapper_syscall_enter(struct child *child, struct trace_sysarg *sysarg) {
 	if (!type)
 		return;
 
-	s128 timeout = TIMEOUT_UNKNOWN;
+	flux_time timeout = TIMEOUT_UNKNOWN;
 	switch (type) {
 	case TYPE_MSEC:
 		if (value < 0) {
@@ -122,8 +122,8 @@ void wrapper_syscall_enter(struct child *child, struct trace_sysarg *sysarg) {
 		PRINT(" ~  %i blocking on %s() for %.3f sec",
 		      child->pid, syscall_to_str(sysarg->number),
 		      timeout / 1000000000.);
-		child->blocked_until = (s128)TIMESPEC_NSEC(&uevent_now) +
-			child->parent->time_drift + (s128)timeout;
+		child->blocked_until = (flux_time)TIMESPEC_NSEC(&uevent_now) +
+			child->parent->time_drift + (flux_time)timeout;
 	}
 	child->syscall_no = sysarg->number;
 }
@@ -140,7 +140,7 @@ int wrapper_syscall_exit(struct child *child, struct trace_sysarg *sysarg) {
 				FATAL("%li ", sysarg->arg1);
 			struct timespec ts;
 			clock_gettime(CLOCK_REALTIME, &ts);
-			s128 newtime = TIMESPEC_NSEC(&ts) + child->parent->time_drift;
+			flux_time newtime = TIMESPEC_NSEC(&ts) + child->parent->time_drift;
 			ts = NSEC_TIMESPEC(newtime);
 			copy_to_user(child->process, sysarg->arg2, &ts,
 				     sizeof(struct timespec));


### PR DESCRIPTION
Commit [`1ba346eb618fe5a5ec65e855a5a33bde90bd2c94`](https://github.com/majek/fluxcapacitor/commit/1ba346eb618fe5a5ec65e855a5a33bde90bd2c94) changed the type used to hold time values from `u64` to `s128`. Unfortunately, when I try to compile fluxcapacitor on a 32-bit architecture, gcc complains that 128-bit integers are not supported.

This changeset adds a new typedef, `flux_time`, which keeps the mapping to `s128` on x86_64, but falls back to `u64` on x86 and ARM.

**Note**: the linked commit also introduced a test that checks for time value wraparound. I imagine it might be good to disable this test on 32-bit arches, as it will most likely fail. Unfortunately I don't know enough Python to write a reliable "did we compile a 32-bit executable" check.