### PR TITLE
Disable the wraparound test on 32-bit architectures

### DIFF
--- a/tests/tests_basic.py
+++ b/tests/tests_basic.py
@@ -208,9 +208,10 @@ class SingleProcess(tests.TestCase):
 
     @at_most(seconds=4)
     def test_2546_wraparound(self):
-        stdout = self.system("bash -c 'for i in `seq 1 55`; do sleep 315360000; done; date +%Y'",
-                             capture_stdout=True)
-        assert int(stdout) > 2500
+        if os.uname()[4] == "x86_64":
+            stdout = self.system("bash -c 'for i in `seq 1 55`; do sleep 315360000; done; date +%Y'",
+                                 capture_stdout=True)
+            assert int(stdout) > 2500
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Pull Request #18 made the program use 64-bit time values on 32-bit architectures. However, the program test suite contains one test which always fails when using 64-bit time values. This patch disabled said test on 32-bit architectures; it will still be run on 64-bit architectures, testing whether 128-bit time values are truly used.